### PR TITLE
🐛 enhance request handler to check for JSON content type before parsi…

### DIFF
--- a/src/lib/requester/request.ts
+++ b/src/lib/requester/request.ts
@@ -32,8 +32,13 @@ const request = async <TData>(
     );
   }
 
-  const data: TData = await response.json();
-  return data;
+  const contentType = response.headers.get("content-type");
+  if (contentType && contentType.includes("application/json")) {
+    const data: TData = await response.json();
+    return data;
+  }
+
+  return {} as TData;
 };
 
 export type { FetchOptions as ApiRequestConfig };


### PR DESCRIPTION
…ng response, returning an empty object for non-JSON responses